### PR TITLE
fix: replace flaky choco protoc install with arduino/setup-protoc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,17 +89,10 @@ jobs:
         with:
           targets: wasm32-wasip2,${{ matrix.target }}
 
-      - name: Install protoc (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
-      - name: Install protoc (macOS)
-        if: runner.os == 'macOS'
-        run: brew install protobuf
-
-      - name: Install protoc (Windows)
-        if: runner.os == 'Windows'
-        run: choco install protoc
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache cargo
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- Fixes the Windows release build failure observed for monaka-v0.2.4.
- `choco install protoc` hit a 504 from community.chocolatey.org, installed 0 packages, and still exited 0, so the later `cargo build` panicked when prost-build couldn't find protoc ([failed run](https://github.com/ternbusty/monaka-fs/actions/runs/24597262104)).
- Collapses the three OS-specific install steps into a single `arduino/setup-protoc@v3`, which fetches protoc directly from the protobuf GitHub releases and removes the chocolatey flakiness.

## Verification
- Workflow file parses cleanly (CI runs were queued for this PR with no workflow annotations).
- The build matrix in `release.yml` only runs on `workflow_run` after a release-please bump on `main`, so the Windows / Linux / macOS protoc paths cannot be exercised on this PR. They will be exercised on the next release.