### PR TITLE
refactor: dedupe path/stat helpers in adapters and CLI

### DIFF
--- a/crates/adapters/rpc-adapter/src/lib.rs
+++ b/crates/adapters/rpc-adapter/src/lib.rs
@@ -307,6 +307,46 @@ fn rpc_error_to_wasi(code: RpcErrorCode) -> ErrorCode {
     }
 }
 
+// Normalise a relative path coming from a WASI caller into the absolute form
+// (`/foo/bar`) the RPC server expects.
+fn normalize_path(path: &str) -> String {
+    format!("/{}", path.trim_start_matches('/'))
+}
+
+// Build a `DescriptorStat` from RPC metadata. Timestamps are not carried by
+// the protocol today, so they are returned as `None`.
+fn make_descriptor_stat(is_dir: bool, size: u64) -> DescriptorStat {
+    DescriptorStat {
+        type_: if is_dir {
+            DescriptorType::Directory
+        } else {
+            DescriptorType::RegularFile
+        },
+        link_count: 1,
+        size: size as Filesize,
+        data_access_timestamp: None,
+        data_modification_timestamp: None,
+        status_change_timestamp: None,
+    }
+}
+
+// Issue a `Seek { fd, offset, whence: 0 }` request on the given persistent
+// connection and consume the response. Used by the read/write paths that
+// need to set the file cursor before doing IO atomically.
+fn seek_via_conn(conn: &mut PersistentConnection, fd: u32, offset: u64) -> Result<(), ErrorCode> {
+    let seek_request = Request::Seek {
+        fd,
+        offset: offset as i64,
+        whence: 0,
+    };
+    conn.send(&seek_request)?;
+    match conn.receive()? {
+        Response::Position { .. } => Ok(()),
+        Response::Error { code, .. } => Err(rpc_error_to_wasi(code)),
+        _ => Err(ErrorCode::Io),
+    }
+}
+
 // Convert WASI flags to fs-core flags
 fn convert_flags(open_flags: OpenFlags, descriptor_flags: DescriptorFlags) -> u32 {
     let mut flags = 0u32;
@@ -471,19 +511,7 @@ impl exports::wasi::filesystem::types::GuestDescriptor for DescriptorImpl {
 
         // Use persistent connection to perform seek + read atomically
         with_connection(|conn| {
-            // Seek to offset
-            let seek_request = Request::Seek {
-                fd: server_fd,
-                offset: offset as i64,
-                whence: 0,
-            };
-            conn.send(&seek_request)?;
-
-            match conn.receive()? {
-                Response::Position { .. } => {}
-                Response::Error { code, .. } => return Err(rpc_error_to_wasi(code)),
-                _ => return Err(ErrorCode::Io),
-            }
+            seek_via_conn(conn, server_fd, offset)?;
 
             // Read data
             let read_request = Request::Read {
@@ -508,19 +536,7 @@ impl exports::wasi::filesystem::types::GuestDescriptor for DescriptorImpl {
 
         // Use persistent connection to perform seek + write atomically
         with_connection(|conn| {
-            // Seek to offset
-            let seek_request = Request::Seek {
-                fd: server_fd,
-                offset: offset as i64,
-                whence: 0,
-            };
-            conn.send(&seek_request)?;
-
-            match conn.receive()? {
-                Response::Position { .. } => {}
-                Response::Error { code, .. } => return Err(rpc_error_to_wasi(code)),
-                _ => return Err(ErrorCode::Io),
-            }
+            seek_via_conn(conn, server_fd, offset)?;
 
             // Write data
             let write_request = Request::Write {
@@ -577,7 +593,7 @@ impl exports::wasi::filesystem::types::GuestDescriptor for DescriptorImpl {
     fn create_directory_at(&self, path: String) -> Result<(), ErrorCode> {
         // For root directory, use direct path
         let full_path = if self.handle == 0 {
-            format!("/{}", path.trim_start_matches('/'))
+            normalize_path(&path)
         } else {
             // Would need to track paths, for now just use relative
             path
@@ -594,32 +610,16 @@ impl exports::wasi::filesystem::types::GuestDescriptor for DescriptorImpl {
     fn stat(&self) -> Result<DescriptorStat, ErrorCode> {
         if self.handle == 0 {
             // Root directory
-            return Ok(DescriptorStat {
-                type_: DescriptorType::Directory,
-                link_count: 1,
-                size: 0,
-                data_access_timestamp: None,
-                data_modification_timestamp: None,
-                status_change_timestamp: None,
-            });
+            return Ok(make_descriptor_stat(true, 0));
         }
 
         let server_fd = with_rpc_state(|state| state.get_server_fd(self.handle))?;
 
         let request = Request::Fstat { fd: server_fd };
         match rpc_call(&request)? {
-            Response::Metadata { metadata } => Ok(DescriptorStat {
-                type_: if metadata.is_dir {
-                    DescriptorType::Directory
-                } else {
-                    DescriptorType::RegularFile
-                },
-                link_count: 1,
-                size: metadata.size as Filesize,
-                data_access_timestamp: None,
-                data_modification_timestamp: None,
-                status_change_timestamp: None,
-            }),
+            Response::Metadata { metadata } => {
+                Ok(make_descriptor_stat(metadata.is_dir, metadata.size))
+            }
             Response::Error { code, .. } => Err(rpc_error_to_wasi(code)),
             _ => Err(ErrorCode::Io),
         }
@@ -627,25 +627,16 @@ impl exports::wasi::filesystem::types::GuestDescriptor for DescriptorImpl {
 
     fn stat_at(&self, _path_flags: PathFlags, path: String) -> Result<DescriptorStat, ErrorCode> {
         let full_path = if self.handle == 0 {
-            format!("/{}", path.trim_start_matches('/'))
+            normalize_path(&path)
         } else {
             path
         };
 
         let request = Request::Stat { path: full_path };
         match rpc_call(&request)? {
-            Response::Metadata { metadata } => Ok(DescriptorStat {
-                type_: if metadata.is_dir {
-                    DescriptorType::Directory
-                } else {
-                    DescriptorType::RegularFile
-                },
-                link_count: 1,
-                size: metadata.size as Filesize,
-                data_access_timestamp: None,
-                data_modification_timestamp: None,
-                status_change_timestamp: None,
-            }),
+            Response::Metadata { metadata } => {
+                Ok(make_descriptor_stat(metadata.is_dir, metadata.size))
+            }
             Response::Error { code, .. } => Err(rpc_error_to_wasi(code)),
             _ => Err(ErrorCode::Io),
         }
@@ -679,7 +670,7 @@ impl exports::wasi::filesystem::types::GuestDescriptor for DescriptorImpl {
         flags: DescriptorFlags,
     ) -> Result<Descriptor, ErrorCode> {
         let full_path = if self.handle == 0 {
-            format!("/{}", path.trim_start_matches('/'))
+            normalize_path(&path)
         } else {
             path
         };
@@ -708,7 +699,7 @@ impl exports::wasi::filesystem::types::GuestDescriptor for DescriptorImpl {
 
     fn remove_directory_at(&self, path: String) -> Result<(), ErrorCode> {
         let full_path = if self.handle == 0 {
-            format!("/{}", path.trim_start_matches('/'))
+            normalize_path(&path)
         } else {
             path
         };
@@ -728,12 +719,12 @@ impl exports::wasi::filesystem::types::GuestDescriptor for DescriptorImpl {
         new_path: String,
     ) -> Result<(), ErrorCode> {
         let old_full = if self.handle == 0 {
-            format!("/{}", old_path.trim_start_matches('/'))
+            normalize_path(&old_path)
         } else {
             old_path
         };
         let new_full = if self.handle == 0 {
-            format!("/{}", new_path.trim_start_matches('/'))
+            normalize_path(&new_path)
         } else {
             new_path
         };
@@ -754,7 +745,7 @@ impl exports::wasi::filesystem::types::GuestDescriptor for DescriptorImpl {
 
     fn unlink_file_at(&self, path: String) -> Result<(), ErrorCode> {
         let full_path = if self.handle == 0 {
-            format!("/{}", path.trim_start_matches('/'))
+            normalize_path(&path)
         } else {
             path
         };
@@ -841,18 +832,7 @@ impl exports::wasi::io::streams::GuestInputStream for FileInputStream {
         };
 
         let result = with_connection(|conn| {
-            let seek_request = Request::Seek {
-                fd: server_fd,
-                offset: current_offset as i64,
-                whence: 0,
-            };
-            conn.send(&seek_request)?;
-
-            match conn.receive()? {
-                Response::Position { .. } => {}
-                Response::Error { code, .. } => return Err(rpc_error_to_wasi(code)),
-                _ => return Err(ErrorCode::Io),
-            }
+            seek_via_conn(conn, server_fd, current_offset)?;
 
             let read_request = Request::Read {
                 fd: server_fd,
@@ -942,18 +922,7 @@ impl FileOutputStream {
             })
         } else {
             with_connection(|conn| {
-                // Seek to start offset
-                let seek_request = Request::Seek {
-                    fd: server_fd,
-                    offset: start_offset as i64,
-                    whence: 0,
-                };
-                conn.send(&seek_request)?;
-                match conn.receive()? {
-                    Response::Position { .. } => {}
-                    Response::Error { code, .. } => return Err(rpc_error_to_wasi(code)),
-                    _ => return Err(ErrorCode::Io),
-                }
+                seek_via_conn(conn, server_fd, start_offset)?;
 
                 // Write all data at once
                 let write_request = Request::Write {

--- a/crates/adapters/vfs-adapter/src/lib.rs
+++ b/crates/adapters/vfs-adapter/src/lib.rs
@@ -244,6 +244,29 @@ fn to_error_code(err: FsError) -> ErrorCode {
     }
 }
 
+// Normalise a relative path coming from a WASI caller into the absolute form
+// fs-core expects (`/foo/bar`).
+fn normalize_path(path: &str) -> String {
+    format!("/{}", path.trim_start_matches('/'))
+}
+
+// Build a `DescriptorStat` from the given type and fs-core metadata,
+// populating WASI timestamps from the metadata's `created` / `modified` fields.
+fn make_descriptor_stat(type_: DescriptorType, metadata: &fs_core::Metadata) -> DescriptorStat {
+    let to_datetime = |secs: u64| wasi::clocks::wall_clock::Datetime {
+        seconds: secs,
+        nanoseconds: 0,
+    };
+    DescriptorStat {
+        type_,
+        link_count: 1,
+        size: metadata.size,
+        data_access_timestamp: Some(to_datetime(metadata.created)),
+        data_modification_timestamp: Some(to_datetime(metadata.modified)),
+        status_change_timestamp: Some(to_datetime(metadata.modified)),
+    }
+}
+
 // Convert WASI flags to fs-core flags
 fn convert_flags(open_flags: OpenFlags, descriptor_flags: DescriptorFlags) -> u32 {
     let mut flags = 0u32;
@@ -596,7 +619,7 @@ impl exports::wasi::filesystem::types::GuestDescriptor for DescriptorImpl {
                 state
                     .fs
                     .borrow_mut()
-                    .mkdir(&format!("/{}", path.trim_start_matches('/')))
+                    .mkdir(&normalize_path(&path))
                     .map_err(to_error_code)
             } else {
                 Err(ErrorCode::Unsupported)
@@ -608,23 +631,7 @@ impl exports::wasi::filesystem::types::GuestDescriptor for DescriptorImpl {
         with_vfs_state(|state| {
             if self.handle == 0 {
                 let metadata = state.fs.borrow_mut().stat("/").map_err(to_error_code)?;
-                return Ok(DescriptorStat {
-                    type_: DescriptorType::Directory,
-                    link_count: 1,
-                    size: metadata.size,
-                    data_access_timestamp: Some(wasi::clocks::wall_clock::Datetime {
-                        seconds: metadata.created,
-                        nanoseconds: 0,
-                    }),
-                    data_modification_timestamp: Some(wasi::clocks::wall_clock::Datetime {
-                        seconds: metadata.modified,
-                        nanoseconds: 0,
-                    }),
-                    status_change_timestamp: Some(wasi::clocks::wall_clock::Datetime {
-                        seconds: metadata.modified,
-                        nanoseconds: 0,
-                    }),
-                });
+                return Ok(make_descriptor_stat(DescriptorType::Directory, &metadata));
             }
 
             let fd = state.get_fd(self.handle)?;
@@ -636,30 +643,14 @@ impl exports::wasi::filesystem::types::GuestDescriptor for DescriptorImpl {
                 DescriptorType::RegularFile
             };
 
-            Ok(DescriptorStat {
-                type_,
-                link_count: 1,
-                size: metadata.size,
-                data_access_timestamp: Some(wasi::clocks::wall_clock::Datetime {
-                    seconds: metadata.created,
-                    nanoseconds: 0,
-                }),
-                data_modification_timestamp: Some(wasi::clocks::wall_clock::Datetime {
-                    seconds: metadata.modified,
-                    nanoseconds: 0,
-                }),
-                status_change_timestamp: Some(wasi::clocks::wall_clock::Datetime {
-                    seconds: metadata.modified,
-                    nanoseconds: 0,
-                }),
-            })
+            Ok(make_descriptor_stat(type_, &metadata))
         })
     }
 
     fn stat_at(&self, _path_flags: PathFlags, path: String) -> Result<DescriptorStat, ErrorCode> {
         with_vfs_state(|state| {
             let full_path = if self.handle == 0 {
-                format!("/{}", path.trim_start_matches('/'))
+                normalize_path(&path)
             } else {
                 return Err(ErrorCode::Unsupported);
             };
@@ -676,23 +667,7 @@ impl exports::wasi::filesystem::types::GuestDescriptor for DescriptorImpl {
                 DescriptorType::RegularFile
             };
 
-            Ok(DescriptorStat {
-                type_,
-                link_count: 1,
-                size: metadata.size,
-                data_access_timestamp: Some(wasi::clocks::wall_clock::Datetime {
-                    seconds: metadata.created,
-                    nanoseconds: 0,
-                }),
-                data_modification_timestamp: Some(wasi::clocks::wall_clock::Datetime {
-                    seconds: metadata.modified,
-                    nanoseconds: 0,
-                }),
-                status_change_timestamp: Some(wasi::clocks::wall_clock::Datetime {
-                    seconds: metadata.modified,
-                    nanoseconds: 0,
-                }),
-            })
+            Ok(make_descriptor_stat(type_, &metadata))
         })
     }
 
@@ -745,7 +720,7 @@ impl exports::wasi::filesystem::types::GuestDescriptor for DescriptorImpl {
             // Use open_at if available, otherwise fall back to absolute path for root
             let (fd, full_path) = if self.handle == 0 {
                 // Root directory: use absolute path
-                let full_path = format!("/{}", path.trim_start_matches('/'));
+                let full_path = normalize_path(&path);
                 let fd = state
                     .fs
                     .borrow_mut()
@@ -783,7 +758,7 @@ impl exports::wasi::filesystem::types::GuestDescriptor for DescriptorImpl {
         with_vfs_state(|state| {
             // For root descriptor, use absolute path
             let full_path = if self.handle == 0 {
-                format!("/{}", path.trim_start_matches('/'))
+                normalize_path(&path)
             } else {
                 return Err(ErrorCode::Unsupported);
             };
@@ -805,11 +780,11 @@ impl exports::wasi::filesystem::types::GuestDescriptor for DescriptorImpl {
     ) -> Result<(), ErrorCode> {
         with_vfs_state(|state| {
             let old_full = if self.handle == 0 {
-                format!("/{}", old_path.trim_start_matches('/'))
+                normalize_path(&old_path)
             } else {
                 return Err(ErrorCode::Unsupported);
             };
-            let new_full = format!("/{}", new_path.trim_start_matches('/'));
+            let new_full = normalize_path(&new_path);
             state
                 .fs
                 .borrow_mut()
@@ -826,7 +801,7 @@ impl exports::wasi::filesystem::types::GuestDescriptor for DescriptorImpl {
         with_vfs_state(|state| {
             // For root descriptor, use absolute path
             let full_path = if self.handle == 0 {
-                format!("/{}", path.trim_start_matches('/'))
+                normalize_path(&path)
             } else {
                 return Err(ErrorCode::Unsupported);
             };
@@ -872,7 +847,7 @@ impl exports::wasi::filesystem::types::GuestDescriptor for DescriptorImpl {
     ) -> Result<exports::wasi::filesystem::types::MetadataHashValue, ErrorCode> {
         with_vfs_state(|state| {
             let full_path = if self.handle == 0 {
-                format!("/{}", path.trim_start_matches('/'))
+                normalize_path(&path)
             } else {
                 return Err(ErrorCode::Unsupported);
             };

--- a/crates/tools/monaka-cli/src/embed.rs
+++ b/crates/tools/monaka-cli/src/embed.rs
@@ -23,12 +23,9 @@ pub fn run(output: &PathBuf, mounts: &[String], s3_sync: bool) -> Result<()> {
     embed_snapshot_bytes(adapter_bytes, output, &snapshot)
 }
 
-/// Embed files into a WASM binary provided as bytes. Used by both `embed` and `compose --mount`.
-pub fn embed_into_bytes(wasm_bytes: &[u8], mounts: &[(String, PathBuf)]) -> Result<Vec<u8>> {
-    let snapshot = build_snapshot(mounts)?;
-    let snapshot_json = serde_json::to_string(&snapshot)?;
-    let snapshot_bytes = snapshot_json.as_bytes();
-
+/// Verify that the given bytes are a WASM Component, returning an error
+/// otherwise. Both `embed` and `compose --mount` reject bare core modules.
+fn ensure_wasm_component(wasm_bytes: &[u8]) -> Result<()> {
     let is_component = wasmparser::Parser::new(0)
         .parse_all(wasm_bytes)
         .find_map(|payload| {
@@ -43,6 +40,16 @@ pub fn embed_into_bytes(wasm_bytes: &[u8], mounts: &[(String, PathBuf)]) -> Resu
     if !is_component {
         bail!("Only WASM Components are supported.");
     }
+    Ok(())
+}
+
+/// Embed files into a WASM binary provided as bytes. Used by both `embed` and `compose --mount`.
+pub fn embed_into_bytes(wasm_bytes: &[u8], mounts: &[(String, PathBuf)]) -> Result<Vec<u8>> {
+    let snapshot = build_snapshot(mounts)?;
+    let snapshot_json = serde_json::to_string(&snapshot)?;
+    let snapshot_bytes = snapshot_json.as_bytes();
+
+    ensure_wasm_component(wasm_bytes)?;
 
     embed_into_component(wasm_bytes, snapshot_bytes)
 }
@@ -61,20 +68,7 @@ fn embed_snapshot_bytes(wasm_bytes: &[u8], output: &Path, snapshot: &FsSnapshot)
             .count()
     );
 
-    let is_component = wasmparser::Parser::new(0)
-        .parse_all(wasm_bytes)
-        .find_map(|payload| {
-            if let Ok(wasmparser::Payload::Version { encoding, .. }) = payload {
-                Some(encoding == wasmparser::Encoding::Component)
-            } else {
-                None
-            }
-        })
-        .unwrap_or(false);
-
-    if !is_component {
-        bail!("Only WASM Components are supported.");
-    }
+    ensure_wasm_component(wasm_bytes)?;
 
     let output_wasm = embed_into_component(wasm_bytes, snapshot_bytes)?;
     std::fs::write(output, &output_wasm)?;


### PR DESCRIPTION
Extract a handful of repeated patterns so future fixes only have to land in one place per crate.

vfs-adapter and rpc-adapter both fan out the WASI relative-path convention into the absolute form fs-core / vfs-rpc-server expect via `format!("/{}", path.trim_start_matches('/'))`. That call appeared seven and seven times respectively. It is now a single `fn normalize_path(path: &str) -> String` per crate, called from every mkdir/stat/rename/unlink/etc. site.

The two adapters also each rebuild a `DescriptorStat` literal in a couple of places. They differ in whether timestamps come from fs-core's `Metadata` (vfs-adapter) or from the protocol response (rpc-adapter, which has no timestamp data and returns `None`). Each crate now owns a local `make_descriptor_stat` helper that captures the right shape and the call sites just hand off the type and the few fields that vary.

Inside rpc-adapter the four read/write paths used to repeat the same nine lines that send a `Request::Seek { whence: 0 }` and pattern-match the `Position` / `Error` reply. Those nine lines now live in `fn seek_via_conn(conn, fd, offset) -> Result<(), ErrorCode>` and each caller becomes a one-liner before its own read/write logic.

The error mapping `to_error_code` (vfs-adapter) and `rpc_error_to_wasi` (rpc-adapter) cover the same eight enum cases, but they take inputs from two independently generated wit-bindgen worlds. The output `ErrorCode` type is also different per crate. Sharing them across crates would need a macro or an intermediate enum that buys little for an eight-case match, so they stay where they are.

monaka-cli's embed.rs ran the same wasmparser-based component-encoding check in two functions. That check now lives in a single `fn ensure_wasm_component(wasm_bytes: &[u8]) -> Result<()>`.

All static-composition (embed / c / s3-sync / image-pipeline) and rpc-server (basic, S3 batch, ci-cache, s3-sync-logging) examples and usecases run unchanged. cargo clippy --all-targets --all-features stays at zero warnings on both native and wasm32-wasip2 builds.