### PR TITLE
ci(build): drop duplicate debug + release build steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,23 +38,30 @@ jobs:
         with:
           components: clippy
 
+      # Per-job cache prefix. `actions/cache` follows first-saver-wins
+      # semantics, so without a per-job prefix the fastest job (Lint)
+      # locks in a thin cache that the slower jobs (Build / E2E) can
+      # never overwrite, leaving sub-workspace deps perpetually missing.
+      # Each job now saves under its own prefix; E2E intentionally
+      # shares the `build-` prefix with Build so its `needs: build`
+      # warmup actually warms.
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
           path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-registry-lint-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo index
         uses: actions/cache@v4
         with:
           path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-git-lint-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo build
         uses: actions/cache@v4
         with:
           path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-build-target-lint-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
@@ -79,13 +86,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-registry-build-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo index
         uses: actions/cache@v4
         with:
           path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-git-build-${{ hashFiles('**/Cargo.lock') }}
 
       # Same cache path/key the e2e job uses, including the sub-workspace
       # target dirs the host-trait runtime-linker examples maintain. The
@@ -105,7 +112,7 @@ jobs:
             usecases/host-trait/sensor-pipeline/sensor-ingest/target
             usecases/host-trait/sensor-pipeline/sensor-process/target
             examples/static-composition/s3-sync/target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-build-target-build-${{ hashFiles('**/Cargo.lock') }}
 
       # The four steps that used to live here
       #   - `cargo build --all-features` (native debug)
@@ -128,7 +135,7 @@ jobs:
       # Pre-warm the parts e2e needs: the demo apps that get composed via
       # monaka, the monaka CLI bundle itself, and the host-trait
       # runtime-linker examples that live in their own Cargo workspaces.
-      - name: Build workspace demo WASMs (release + debug)
+      - name: Pre-build workspace demo WASMs
         run: |
           cargo build --release --target wasm32-wasip2 \
             -p demo-writer -p demo-reader -p demo-fs-operations \
@@ -171,19 +178,19 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-registry-test-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo index
         uses: actions/cache@v4
         with:
           path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-git-test-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo build
         uses: actions/cache@v4
         with:
           path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-build-target-test-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run tests
         run: cargo test --all-features --verbose
@@ -224,18 +231,22 @@ jobs:
         with:
           targets: wasm32-wasip2
 
-      # Share cache with format / lint / build / test jobs.
+      # Share the `build-` cache prefix with the Build job (we depend on
+      # it via `needs: build`, so its Post Cache step has already
+      # finished and saved a fully populated cache by the time this job
+      # restores). Saving under the same key here is a no-op when the
+      # restore was an exact hit.
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
           path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-registry-build-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo index
         uses: actions/cache@v4
         with:
           path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-git-build-${{ hashFiles('**/Cargo.lock') }}
 
       # The host-trait runtime-linker examples and usecases each live in
       # their own Cargo workspace, so they each get their own `target/`
@@ -256,7 +267,7 @@ jobs:
             usecases/host-trait/sensor-pipeline/sensor-ingest/target
             usecases/host-trait/sensor-pipeline/sensor-process/target
             examples/static-composition/s3-sync/target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-build-target-build-${{ hashFiles('**/Cargo.lock') }}
 
       # E2E-specific tooling. wac-cli builds from source (~1-2 min) so cache
       # the resulting binary keyed on its pinned version.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,23 +107,27 @@ jobs:
             examples/static-composition/s3-sync/target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Build native packages
-        run: cargo build --all-features --verbose
-
-      - name: Build WASM packages
-        run: make build-wasm
-
-      - name: Build release (native)
-        run: cargo build --release --all-features --verbose
-
-      - name: Build release (WASM)
-        run: make build-wasm-release
-
-      # Pre-warm the parts the e2e job needs but `cargo build --workspace`
-      # alone doesn't cover: the demo apps that get composed via monaka,
-      # the s3-sync feature variants, the monaka CLI itself, and the
-      # host-trait runtime-linker examples that live in their own
-      # Cargo workspaces.
+      # The four steps that used to live here
+      #   - `cargo build --all-features` (native debug)
+      #   - `make build-wasm` (debug WASM)
+      #   - `cargo build --release --all-features`
+      #   - `make build-wasm-release`
+      # were duplicate work:
+      #   - `make build-cli` below already runs the release WASM builds
+      #     for vfs-adapter, rpc-adapter and vfs-rpc-server (with both the
+      #     s3-sync and plain feature variants) before linking monaka.
+      #   - The host-trait runtime-linker pre-builds further down trigger
+      #     native release compiles of vfs-host / fs-core / vfs-sync-host
+      #     transitively.
+      #   - Debug-mode validation already comes from the Test job's
+      #     `cargo test --all-features`.
+      # Release-build validation tied to shipping (cargo publish, asset
+      # uploads) lives in release.yml. This job is just here to warm the
+      # cargo cache for the e2e job.
+      #
+      # Pre-warm the parts e2e needs: the demo apps that get composed via
+      # monaka, the monaka CLI bundle itself, and the host-trait
+      # runtime-linker examples that live in their own Cargo workspaces.
       - name: Build workspace demo WASMs (release + debug)
         run: |
           cargo build --release --target wasm32-wasip2 \


### PR DESCRIPTION
## Summary

The Build job had four `cargo build` / `make build-wasm*` steps that were doing work already covered elsewhere. Drop them so Build is just the cargo-cache warmup the E2E job downstream depends on.

| Removed step | Why it was duplicate |
|---|---|
| \`cargo build --all-features\` (debug native) | Test job's \`cargo test --all-features\` already compiles in debug |
| \`make build-wasm\` (debug WASM adapters) | Nothing downstream consumes the debug variants of vfs-adapter / rpc-adapter / vfs-rpc-server — E2E uses release |
| \`cargo build --release --all-features\` | The host-trait runtime-linker pre-builds further down trigger release compiles of vfs-host / fs-core / vfs-sync-host transitively, and \`make build-cli\` covers monaka |
| \`make build-wasm-release\` | \`make build-cli\` runs the same release WASM builds (s3-sync + plain feature variants) internally before linking monaka |

Release-build validation tied to shipping (cargo publish, asset uploads) lives in \`release.yml\`, not on every PR. The Build job's only remaining purpose is warming the cargo cache for E2E:

- workspace demo WASMs (release + debug — debug variants are needed because the host-trait runtime-linker examples hard-code those paths)
- \`make build-cli\`
- the host-trait runtime-linker examples (each in its own Cargo workspace)

## Expected impact

- Cold Build run: a few minutes shorter
- Cache-hit Build run: roughly halved (no separate debug-vs-release relink passes)
- E2E job is unchanged

## Test plan

- [ ] CI passes on this branch (Format / Lint / Build / Test / E2E all green)
- [ ] No timing regression in the Test or E2E jobs