### PR TITLE
fix(release): track vfs-rpc-server-core, unblock release-please after #62

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
             ["crates/adapters/rpc-adapter"]="rpc-adapter"
             ["crates/rpc/vfs-rpc-protocol"]="vfs-rpc-protocol"
             ["crates/rpc/vfs-rpc-server"]="vfs-rpc-server"
+            ["crates/rpc/vfs-rpc-server-core"]="vfs-rpc-server-core"
           )
           for path in "${!PACKAGES[@]}"; do
             component="${PACKAGES[$path]}"

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -8,5 +8,6 @@
   "crates/adapters/vfs-adapter": "0.2.4",
   "crates/adapters/rpc-adapter": "0.2.4",
   "crates/rpc/vfs-rpc-protocol": "0.2.4",
-  "crates/rpc/vfs-rpc-server": "0.2.4"
+  "crates/rpc/vfs-rpc-server": "0.2.4",
+  "crates/rpc/vfs-rpc-server-core": "0.2.4"
 }

--- a/crates/core/fs-core/src/lib.rs
+++ b/crates/core/fs-core/src/lib.rs
@@ -1,3 +1,17 @@
+//! In-memory filesystem implementation shared by every Monaka component.
+//!
+//! A single `Fs` type is exposed in two flavours via the `thread-safe`
+//! feature flag:
+//!
+//! - `thread-safe` (requires `std`): backed by `DashMap` plus
+//!   `Arc<RwLock<Inode>>`, used by host-side wasmtime integrations that
+//!   need `Send + Sync`.
+//! - default: backed by `RefCell<HashMap>` or `RefCell<BTreeMap>` plus
+//!   `Rc<RefCell<Inode>>`, used by the WASI components.
+//!
+//! Both flavours share one `&self` API, so consumers only need to pick
+//! the feature flag that matches their target.
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -48,6 +48,11 @@
       "release-type": "rust",
       "component": "vfs-rpc-server",
       "skip-github-release": true
+    },
+    "crates/rpc/vfs-rpc-server-core": {
+      "release-type": "rust",
+      "component": "vfs-rpc-server-core",
+      "skip-github-release": true
     }
   },
   "plugins": [
@@ -68,7 +73,8 @@
         "vfs-adapter",
         "rpc-adapter",
         "vfs-rpc-protocol",
-        "vfs-rpc-server"
+        "vfs-rpc-server",
+        "vfs-rpc-server-core"
       ]
     }
   ]


### PR DESCRIPTION
## Why

Release-please did not generate a release PR after #62 was merged. Looking at the `release-please` job log for that merge ([run 25775898369](https://github.com/ternbusty/monaka-fs/actions/runs/25775898369)):

```
commit could not be parsed: c4ba71df... fix: S3 abort, drop unsafe globals, fs-core unify, RPC server split, UUID session ids (#62)
error message: Error: unexpected token '(' at 107:11, valid tokens [)]
```

Line 107 of #62's squash commit body is the doc fragment `#[cfg(not(target_family = "wasm"))]`. The nested parens in that attribute confuse release-please's conventional-commit parser, so it skips the whole commit. With no parseable user-facing commits since the previous release, no release PR is created.

Force-pushing main to amend the bad commit would be destructive, so this PR adds a new conventional commit whose body is parser-safe. That alone is enough to unblock release-please; the body of this commit also recaps #62's changes so the next release notes carry meaningful entries.

## What

- Register `vfs-rpc-server-core` (added in #62) with release-please: `release-please-config.json` packages + linked-versions, `.release-please-manifest.json` seed at 0.2.4, and `.github/workflows/release.yml` tag-packages step. The crate is `publish = false` so it stays off crates.io but still gets a per-release tag like every other internal crate.
- Add a crate-level docstring to `crates/core/fs-core/src/lib.rs` describing the thread-safe vs default backend split that #62 unified.
- Commit body recaps #62 for the upcoming changelog.

## Test plan
- [x] `cargo build` (workspace) and `cargo build -p fs-core` still build
- [x] Commit message parses cleanly — body contains zero parens
- [ ] After merge, observe the `release-please` job in [Actions](https://github.com/ternbusty/monaka-fs/actions/workflows/release.yml) to confirm a release PR is created