### PR TITLE
ci: reference dtolnay/rust-toolchain via @stable instead of version refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.92.0
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
 
@@ -34,7 +34,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.92.0
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
 
@@ -76,10 +76,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       # Match the e2e job's pin so the warmed cargo cache is reusable
-      # across both jobs.
+      # across both jobs. The ref stays @stable (Dependabot proposes
+      # bumps to unreleased Rust versions for this action's version
+      # refs); the actual pin lives in the `toolchain` input.
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.92.0
+        uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: 1.92.0
           targets: wasm32-wasip2
 
       - name: Cache cargo registry
@@ -172,7 +175,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.92.0
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
         uses: actions/cache@v6
@@ -226,9 +229,13 @@ jobs:
       # panic on close: "cannot use two types with this resource type".
       # The same composition built with 1.92.0 (or on macOS) runs cleanly,
       # so pin until rustc/wit-bindgen sort out the new imports upstream.
+      # The ref stays @stable (Dependabot proposes bumps to unreleased
+      # Rust versions for this action's version refs); the actual pin
+      # lives in the `toolchain` input.
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.92.0
+        uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: 1.92.0
           targets: wasm32-wasip2
 
       # Share the `build-` cache prefix with the Build job (we depend on


### PR DESCRIPTION
## Why

Dependabot opened #71 bumping `dtolnay/rust-toolchain` from 1.92.0 to 1.100.0, and every CI job failed at toolchain install with:

```
error: could not download nonexistent rust version `1.100.0-x86_64-unknown-linux-gnu` (404)
```

The action's version refs are branches whose names double as the Rust version to install, and the maintainer pre-creates refs for unreleased Rust versions (the `1.100.0` ref was created on 2026-07-16, while current stable is 1.97). Dependabot compares refs by semver alone and cannot know the underlying toolchain does not exist yet, so it will keep proposing broken bumps as long as the workflow pins via the action ref.

## What

- Format / Lint / Test jobs now use `dtolnay/rust-toolchain@stable` and track the current stable toolchain, matching what release.yml already does.
- Build / E2E jobs keep the intentional rustc 1.92.0 pin (wasm32-wasip2 std >= 1.95.0 adds `wasi:cli/terminal-*` imports that break `wac plug` composition, see the comment in ci.yml), but the pin now lives in the action's `toolchain` input instead of the ref. The ref itself is `@stable`, which Dependabot skips since it is not a semver ref.

With no versioned refs left in the workflows, Dependabot has nothing to bump for this action. #71 can be closed without merging.